### PR TITLE
add scroll restoration component

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,10 @@
 import React, { Suspense } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Outlet, createRootRoute } from "@tanstack/react-router";
+import {
+  createRootRoute,
+  Outlet,
+  ScrollRestoration,
+} from "@tanstack/react-router";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import { Link } from "@/components/link";
@@ -22,31 +26,34 @@ const TanStackRouterDevtools = import.meta.env.PROD
 const githubSauce: string = "https://github.com/jsegal205/jimsegal-com";
 export const Route = createRootRoute({
   component: () => (
-    <QueryClientProvider client={queryClient}>
-      <DarkModeProvider>
-        <main className="bg-slate-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 min-h-screen flex flex-col justify-between">
-          <Outlet />
+    <>
+      <ScrollRestoration />
+      <QueryClientProvider client={queryClient}>
+        <DarkModeProvider>
+          <main className="bg-slate-100 dark:bg-slate-700 text-slate-900 dark:text-slate-100 min-h-screen flex flex-col justify-between">
+            <Outlet />
 
-          <footer className="self-bottom mb-1">
-            <div className="flex justify-center text-xs">
-              <span className="mr-1">Made with</span>
-              <Icon className="my-auto h-3 w-3 fill-red-500" type="heart" />
-              <span className="mx-1">by Jim Segal</span>(
-              <Link to={githubSauce}>source</Link>
-              <span className="mx-1">on</span>
-              <Icon
-                type="github"
-                className="my-auto h-3 w-3 dark:fill-slate-100"
-              />
-              )
-            </div>
-            <Suspense>
-              <TanStackRouterDevtools />
-              <ReactQueryDevtools />
-            </Suspense>
-          </footer>
-        </main>
-      </DarkModeProvider>
-    </QueryClientProvider>
+            <footer className="self-bottom mb-1">
+              <div className="flex justify-center text-xs">
+                <span className="mr-1">Made with</span>
+                <Icon className="my-auto h-3 w-3 fill-red-500" type="heart" />
+                <span className="mx-1">by Jim Segal</span>(
+                <Link to={githubSauce}>source</Link>
+                <span className="mx-1">on</span>
+                <Icon
+                  type="github"
+                  className="my-auto h-3 w-3 dark:fill-slate-100"
+                />
+                )
+              </div>
+              <Suspense>
+                <TanStackRouterDevtools />
+                <ReactQueryDevtools />
+              </Suspense>
+            </footer>
+          </main>
+        </DarkModeProvider>
+      </QueryClientProvider>
+    </>
   ),
 });

--- a/src/routes/_withnav.tsx
+++ b/src/routes/_withnav.tsx
@@ -1,14 +1,21 @@
 import { HeaderNav } from "@/components/headerNav";
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  Outlet,
+  ScrollRestoration,
+} from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_withnav")({
   component: () => (
-    <section className="m-4">
-      <HeaderNav />
+    <>
+      <ScrollRestoration />
+      <section className="m-4">
+        <HeaderNav />
 
-      <section className="p-4">
-        <Outlet />
+        <section className="p-4">
+          <Outlet />
+        </section>
       </section>
-    </section>
+    </>
   ),
 });


### PR DESCRIPTION
https://tanstack.com/router/latest/docs/framework/react/guide/scroll-restoration

repo steps
- nav to ~/recipes
- scroll to one of the bottom recipes
- click a recipe like turkey chili or veggie chili

Expected - 
recipe is scrolled to the top of the browser

Actual
recipe retains scroll position